### PR TITLE
Potential fix for code scanning alert no. 4: DOM text reinterpreted as HTML

### DIFF
--- a/PreciseAlloy.Frontend/xpack/react-loader.tsx
+++ b/PreciseAlloy.Frontend/xpack/react-loader.tsx
@@ -8,17 +8,7 @@ const blocks: Record<string, React.LazyExoticComponent<React.ComponentType<any>>
   ...clientComponents,
 };
 
-const SAFE_CONTAINER_TAGS = new Set([
-  'section',
-  'div',
-  'article',
-  'main',
-  'aside',
-  'header',
-  'footer',
-  'nav',
-  'span',
-]);
+const SAFE_CONTAINER_TAGS = new Set(['div', 'section']);
 
 const getSafeTagName = (tagName: string | null): string => {
   const normalizedTag = (tagName ?? '').trim().toLowerCase();

--- a/PreciseAlloy.Frontend/xpack/react-loader.tsx
+++ b/PreciseAlloy.Frontend/xpack/react-loader.tsx
@@ -8,6 +8,23 @@ const blocks: Record<string, React.LazyExoticComponent<React.ComponentType<any>>
   ...clientComponents,
 };
 
+const SAFE_CONTAINER_TAGS = new Set([
+  'section',
+  'div',
+  'article',
+  'main',
+  'aside',
+  'header',
+  'footer',
+  'nav',
+  'span',
+]);
+
+const getSafeTagName = (tagName: string | null): string => {
+  const normalizedTag = (tagName ?? '').trim().toLowerCase();
+  return SAFE_CONTAINER_TAGS.has(normalizedTag) ? normalizedTag : 'section';
+};
+
 const renderComponent = (scriptSection: HTMLScriptElement) => {
   const blockType = scriptSection.getAttribute('data-rct');
   const data = scriptSection.textContent ? scriptSection.textContent : '{}';
@@ -20,7 +37,8 @@ const renderComponent = (scriptSection: HTMLScriptElement) => {
 
   if (Component) {
     scriptSection.textContent = null;
-    const section = document.createElement(scriptSection.getAttribute('data-tag') ?? 'section');
+    const tagName = getSafeTagName(scriptSection.getAttribute('data-tag'));
+    const section = document.createElement(tagName);
 
     section.className = scriptSection.getAttribute('data-class') ?? '';
     scriptSection.replaceWith(section);

--- a/PreciseAlloy.Frontend/xpack/scripts/root.entry.ts
+++ b/PreciseAlloy.Frontend/xpack/scripts/root.entry.ts
@@ -139,7 +139,7 @@ const setup = () => {
 
   const wrapper = getWrapper();
   if (wrapper) {
-    window.onload = () => wrapper.classList.add('initialized');
+    window.addEventListener('load', () => wrapper.classList.add('initialized'));
   }
 };
 

--- a/PreciseAlloy.Frontend/xpack/styles-core.ts
+++ b/PreciseAlloy.Frontend/xpack/styles-core.ts
@@ -33,7 +33,7 @@ export const prepareCssFileContent = (
       : undefined,
     includeMixins ? slash(`@use '${path.relative(path.dirname(srcFile), path.resolve('src/assets/styles/01-mixins/mixins'))}' as *;\n`) : undefined,
     dependencies.readFileSync(srcFile, 'utf-8'),
-  ].filter(Boolean);
+  ].filter((content): content is string => content !== undefined);
 };
 
 export const resolveSourceMapPath = (source: string, sourceRoot?: string | null): string | undefined => {

--- a/PreciseAlloy.Frontend/xpack/styles.ts
+++ b/PreciseAlloy.Frontend/xpack/styles.ts
@@ -63,8 +63,8 @@ const getCssSourceContent = (srcFile: string, mode: 'importer' | 'compile'): str
   return prepareCssFileContent({ srcFile });
 };
 
-const stringOptions = (srcFile: string): sass.StringOptions<'async'> => {
-  const options: sass.StringOptions<'async'> = {
+const getStringOptions = <Sync extends 'sync' | 'async'>(srcFile: string): sass.StringOptions<Sync> => {
+  const options: sass.StringOptions<Sync> = {
     sourceMap: true,
     sourceMapIncludeSources: true,
     syntax: 'scss',
@@ -120,19 +120,19 @@ const compile = (srcFile: string, options: { prefix?: string; isReady: boolean }
   if (srcFile.includes('style-base') || srcFile.includes('style-all')) {
     glob.sync('./src/atoms/**/*.scss').forEach((atomPath) => {
       if (!path.basename(atomPath).startsWith('_')) {
-        cssStrings.push(sass.compileString(prepareCssFileContent({ srcFile: atomPath }).join(''), stringOptions(atomPath)).css);
+        cssStrings.push(sass.compileString(prepareCssFileContent({ srcFile: atomPath }).join(''), getStringOptions<'sync'>(atomPath)).css);
       }
     });
 
     glob.sync('./src/molecules/**/*.scss').forEach((molPath) => {
       if (!path.basename(molPath).startsWith('_')) {
-        cssStrings.push(sass.compileString(prepareCssFileContent({ srcFile: molPath }).join(''), stringOptions(molPath)).css);
+        cssStrings.push(sass.compileString(prepareCssFileContent({ srcFile: molPath }).join(''), getStringOptions<'sync'>(molPath)).css);
       }
     });
   }
 
   sass
-    .compileStringAsync(cssStrings.join(''), stringOptions(srcFile))
+    .compileStringAsync(cssStrings.join(''), getStringOptions<'async'>(srcFile))
     .then((result) => postcssProcess(result, srcFile, outFile))
     .catch((error) => {
       log(error);


### PR DESCRIPTION
Potential fix for [https://github.com/precise-alloy/precise-alloy/security/code-scanning/4](https://github.com/precise-alloy/precise-alloy/security/code-scanning/4)

Best fix: validate `data-tag` against a strict allowlist of safe container tags before calling `document.createElement`. If value is missing or not allowed, fall back to `'section'`.

In `PreciseAlloy.Frontend/xpack/react-loader.tsx`, add:
- A `SAFE_CONTAINER_TAGS` set (for example: `section`, `div`, `article`, `main`, `aside`, `header`, `footer`, `nav`, `span`).
- A small helper `getSafeTagName` that normalizes to lowercase and returns `'section'` unless the value is allowlisted.
- Replace the current `document.createElement(scriptSection.getAttribute('data-tag') ?? 'section')` with:
  1) read raw tag,
  2) sanitize via helper,
  3) create element from sanitized tag.

No dependency changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
