### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cms12.yaml
+++ b/.github/workflows/cms12.yaml
@@ -15,6 +15,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"


### PR DESCRIPTION
Potential fix for [https://github.com/precise-alloy/precise-alloy/security/code-scanning/1](https://github.com/precise-alloy/precise-alloy/security/code-scanning/1)

Add an explicit `permissions` block in `.github/workflows/cms12.yaml` at the workflow root (best place since there is one job and it documents baseline security for the whole workflow).  
Use least privilege needed by current steps: `contents: read` is sufficient for checkout and does not change intended functionality.

**Exact change region**: insert after `concurrency` block (after line 16 in the provided snippet), before `jobs:`.

No imports/dependencies/methods are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
