### PR TITLE
Potential fix for code scanning alert no. 5: Exception text reinterpreted as HTML

### DIFF
--- a/PreciseAlloy.Frontend/xpack/renderer.ts
+++ b/PreciseAlloy.Frontend/xpack/renderer.ts
@@ -143,7 +143,7 @@ export const _useRenderer = ({ app, indexProd, isProd, viteDevServer, resolve }:
     } catch (e: any) {
       !isProd && viteDevServer!.ssrFixStacktrace(e);
       console.log(e.stack);
-      res.status(500).end(e.stack);
+      res.status(500).end('Internal Server Error');
     }
   });
 };


### PR DESCRIPTION
Potential fix for [https://github.com/precise-alloy/precise-alloy/security/code-scanning/5](https://github.com/precise-alloy/precise-alloy/security/code-scanning/5)

General fix: never return raw exception messages/stacks to browser clients as HTML. For production and security, send a generic error body. Keep full error details in server logs only.

Best fix here (without changing intended app behavior): in `PreciseAlloy.Frontend/xpack/renderer.ts`, replace `res.status(500).end(e.stack);` with a safe generic message (e.g., `'Internal Server Error'`). Keep `viteDevServer!.ssrFixStacktrace(e)` and `console.log(e.stack)` as-is for debugging/logging. This single change addresses both alert variants because both terminate at the same sink line.

No new imports, helper methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
