### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -2,6 +2,9 @@
 
 name: Deploy
 
+permissions:
+  contents: read
+
 # Controls when the action will run.
 on:
   # Allows you to run this workflow manually from the Actions tab


### PR DESCRIPTION
Potential fix for [https://github.com/precise-alloy/precise-alloy/security/code-scanning/2](https://github.com/precise-alloy/precise-alloy/security/code-scanning/2)

Add an explicit `permissions` block at the workflow root in `.github/workflows/deploy.yaml`, just below `name:` (or before `jobs:`).  
For this workflow, the minimal safe baseline is:

- `contents: read`

This preserves functionality (`actions/checkout` can still read repository contents) while preventing unintended broader token access if repo/org defaults are permissive now or in the future.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
