### PR TITLE
feat(rtl): add RTL language support toggle for iframe shell

### DIFF
--- a/PreciseAlloy.Frontend/.gitignore
+++ b/PreciseAlloy.Frontend/.gitignore
@@ -43,3 +43,7 @@ public/pl-states.json
 
 # cli
 bin
+
+# claude
+.claude
+**/CLAUDE.md

--- a/PreciseAlloy.Frontend/src/assets/styles/02-base/_style-base.scss
+++ b/PreciseAlloy.Frontend/src/assets/styles/02-base/_style-base.scss
@@ -5,6 +5,12 @@
   -webkit-text-size-adjust: 100%;
 }
 
+.translated-rtl,
+[dir='rtl'] {
+  direction: rtl;
+  --rtl-sign: -1;
+}
+
 body {
   & {
     min-height: 100vh;

--- a/PreciseAlloy.Frontend/src/organisms/header/index.scss
+++ b/PreciseAlloy.Frontend/src/organisms/header/index.scss
@@ -18,7 +18,7 @@
     @include font-h1;
 
     & {
-      margin-right: auto;
+      margin-inline-end: auto;
     }
   }
 

--- a/PreciseAlloy.Frontend/xpack/root/active-item-options.tsx
+++ b/PreciseAlloy.Frontend/xpack/root/active-item-options.tsx
@@ -5,7 +5,7 @@ import { useOnClickOutside } from './use-click-outside';
 import StateAnimationHtml from './state-animation-html';
 
 export default function ActiveItemOptions() {
-  const { activeItem, isTopPanel } = useRootContext();
+  const { activeItem, isTopPanel, isRtl } = useRootContext();
   const key = 'pl-show-state-selector';
   const keyExist = localStorage.getItem(key);
   const optionItemsRef = createRef<HTMLDivElement>();
@@ -40,6 +40,14 @@ export default function ActiveItemOptions() {
     setShow(!show);
   };
 
+  const handleRtlToggle = () => {
+    const key = 'MSG_IS_RTL';
+    const value = isRtl ? 'false' : 'true';
+    localStorage.setItem(key, value);
+    window.dispatchEvent(new StorageEvent('storage', { key, newValue: value }));
+    setShow(false);
+  };
+
   const handleChangePanelPosition = () => {
     const key = 'MSG_IS_TOP_PANEL';
     const value = isTopPanel ? 'false' : 'true';
@@ -71,6 +79,10 @@ export default function ActiveItemOptions() {
 
         <button className="xpack-o-root__nav-item pl-state-toggle" onClick={handleThemeToggle}>
           Change theme
+        </button>
+
+        <button className="xpack-o-root__nav-item" onClick={handleRtlToggle}>
+          {isRtl ? 'Disable RTL' : 'Enable RTL'}
         </button>
 
         <button className="xpack-o-root__nav-item panel-position" onClick={handleChangePanelPosition}>

--- a/PreciseAlloy.Frontend/xpack/root/index.tsx
+++ b/PreciseAlloy.Frontend/xpack/root/index.tsx
@@ -12,6 +12,7 @@ export default function Root(props: RootModel) {
   const [isTopPanel, setTopPanel] = useState<boolean>(() =>
     typeof localStorage !== 'undefined' ? localStorage.getItem('MSG_IS_TOP_PANEL') === 'true' : false
   );
+  const [isRtl, setRtl] = useState<boolean>(() => (typeof localStorage !== 'undefined' ? localStorage.getItem('MSG_IS_RTL') === 'true' : false));
 
   useEffect(() => {
     if (!activeItem) {
@@ -33,6 +34,8 @@ export default function Root(props: RootModel) {
     setActiveItem,
     isTopPanel,
     setTopPanel,
+    isRtl,
+    setRtl,
   };
 
   const routes = useMemo(() => {
@@ -80,6 +83,9 @@ export default function Root(props: RootModel) {
       case 'MSG_IS_TOP_PANEL':
         setTopPanel(event.newValue === 'true');
         break;
+      case 'MSG_IS_RTL':
+        setRtl(event.newValue === 'true');
+        break;
     }
   };
 
@@ -90,6 +96,25 @@ export default function Root(props: RootModel) {
       window.removeEventListener('storage', handleStorageChange);
     };
   }, []);
+
+  useEffect(() => {
+    const frame = document.querySelector<HTMLIFrameElement>('#root-iframe');
+
+    if (!frame) {
+      return;
+    }
+
+    const applyDir = () => {
+      frame.contentDocument?.documentElement.setAttribute('dir', isRtl ? 'rtl' : 'ltr');
+    };
+
+    applyDir();
+    frame.addEventListener('load', applyDir);
+
+    return () => {
+      frame.removeEventListener('load', applyDir);
+    };
+  }, [isRtl]);
 
   return routes ? (
     <RootContext.Provider value={rootData}>

--- a/PreciseAlloy.Frontend/xpack/root/root-context.ts
+++ b/PreciseAlloy.Frontend/xpack/root/root-context.ts
@@ -5,6 +5,8 @@ export interface RootData {
   setActiveItem: (item?: SinglePageNode) => void;
   isTopPanel?: boolean;
   setTopPanel: (isTopPanel: boolean) => void;
+  isRtl: boolean;
+  setRtl: (value: boolean) => void;
 }
 
 export const RootContext = createContext<RootData>({
@@ -12,6 +14,10 @@ export const RootContext = createContext<RootData>({
     // empty
   },
   setTopPanel: () => {
+    // empty
+  },
+  isRtl: false,
+  setRtl: () => {
     // empty
   },
 });


### PR DESCRIPTION
## Summary

- **RTL toggle in sidebar**: Adds an "Enable RTL / Disable RTL" button in the xpack navigation active-item options menu. Toggling it persists state to `localStorage` (`MSG_IS_RTL`) and fires a `StorageEvent` so all listeners update synchronously.
- **Iframe direction control**: A `useEffect` in `xpack/root/index.tsx` watches `isRtl` and sets `dir="rtl"` or `dir="ltr"` on the `#root-iframe` document element, re-applying on every iframe `load` event.
- **RTL base styles**: Added `.translated-rtl, [dir='rtl']` rules to `_style-base.scss` (sets `direction: rtl` and a `--rtl-sign: -1` custom property for future RTL-aware calculations).
- **Logical CSS property**: Replaced `margin-right: auto` with `margin-inline-end: auto` in `src/organisms/header/index.scss` so the header layout is direction-aware.
- **Context wiring**: `RootData` interface and context default extended with `isRtl`/`setRtl`; state initialised from localStorage on mount.
- **`.gitignore` update**: Excludes `.claude/` directories and `CLAUDE.md` files from version control.

## Test plan

- [ ] Open the xpack sidebar, click "Enable RTL" — the iframe content should switch to RTL layout.
- [ ] Click "Disable RTL" — the iframe should revert to LTR.
- [ ] Refresh the page — the last-chosen direction should be restored from localStorage.
- [ ] Navigate within the iframe (triggers a `load` event) — direction should re-apply correctly after navigation.
- [ ] Confirm no visual regression in the header layout (logo/nav alignment) in both LTR and RTL modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)